### PR TITLE
Renamed paths to remove "Xamarin" and start using "maui"

### DIFF
--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -144,7 +144,7 @@ namespace Xamarin.MacDev {
 		static AppleSdkSettings ()
 		{
 			var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-			var preferences = Path.Combine (home, "Library", "Preferences", "Xamarin");
+			var preferences = Path.Combine (home, "Library", "Preferences", "maui");
 
 			if (!Directory.Exists (preferences))
 				Directory.CreateDirectory (preferences);

--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -69,7 +69,7 @@ namespace Xamarin.MacDev {
 				var appDataLocal = Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData);
 
 				ProfileDirectories = new string [] {
-					Path.Combine (appDataLocal, "Xamarin", "iOS", "Provisioning", "Profiles")
+					Path.Combine (appDataLocal, "maui", "iOS", "Provisioning", "Profiles")
 				};
 			}
 		}

--- a/Xamarin.MacDev/MobileProvisionIndex.cs
+++ b/Xamarin.MacDev/MobileProvisionIndex.cs
@@ -190,15 +190,15 @@ namespace Xamarin.MacDev {
 
 		static MobileProvisionIndex ()
 		{
-			string xamarinFolder;
+			string provisioningFolder;
 
 			if (Environment.OSVersion.Platform == PlatformID.Unix || Environment.OSVersion.Platform == PlatformID.MacOSX) {
-				xamarinFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Xamarin");
+				provisioningFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Caches", "maui");
 			} else {
-				xamarinFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Xamarin", "iOS", "Provisioning");
+				provisioningFolder = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "maui", "iOS", "Provisioning");
 			}
 
-			IndexFileName = Path.Combine (xamarinFolder, "Provisioning Profiles.index");
+			IndexFileName = Path.Combine (provisioningFolder, "Provisioning Profiles.index");
 		}
 
 		MobileProvisionIndex ()


### PR DESCRIPTION
This is part of the Xamarin deprecation tasks.
The new paths are just used and consumed in this code base. 
The update and migration logic from legacy paths to new paths is handled by the ClientTools.Platform extension. PR: https://dev.azure.com/devdiv/DevDiv/_git/ClientTools.Platform/pullrequest/632938

Par of task: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2428701