### PR TITLE
Load the Xcode path from the old xamarin-based Settings.plist path if the new maui-based path doesn't exist.

### DIFF
--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -153,7 +153,7 @@ namespace Xamarin.MacDev {
 					SettingsPath = oldSettings;
 			}
 
-			Directory.Create (Path.GetDirectoryName (SettingsPath));
+			Directory.CreateDirectory (Path.GetDirectoryName (SettingsPath));
 
 			Init ();
 		}

--- a/Xamarin.MacDev/AppleSdkSettings.cs
+++ b/Xamarin.MacDev/AppleSdkSettings.cs
@@ -144,12 +144,16 @@ namespace Xamarin.MacDev {
 		static AppleSdkSettings ()
 		{
 			var home = Environment.GetFolderPath (Environment.SpecialFolder.UserProfile);
-			var preferences = Path.Combine (home, "Library", "Preferences", "maui");
 
-			if (!Directory.Exists (preferences))
-				Directory.CreateDirectory (preferences);
+			SettingsPath = Path.Combine (home, "Library", "Preferences", "maui", "Settings.plist");
 
-			SettingsPath = Path.Combine (preferences, "Settings.plist");
+			if (!File.Exists (SettingsPath)) {
+				var oldSettings = Path.Combine (home, "Library", "Preferences", "Xamarin", "Settings.plist");
+				if (File.Exists (oldSettings))
+					SettingsPath = oldSettings;
+			}
+
+			Directory.Create (Path.GetDirectoryName (SettingsPath));
 
 			Init ();
 		}


### PR DESCRIPTION
This way existing tooling can be slowly updated instead of having to update everything all at once.

Example: the provisionator hasn't been updated yet to write to the new path.