### PR TITLE
Added backwards compatibility for locating provisioning stuff in legacy Xamarin folders

### DIFF
--- a/Xamarin.MacDev/MobileProvision.cs
+++ b/Xamarin.MacDev/MobileProvision.cs
@@ -69,6 +69,7 @@ namespace Xamarin.MacDev {
 				var appDataLocal = Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData);
 
 				ProfileDirectories = new string [] {
+					Path.Combine (appDataLocal, "Xamarin", "iOS", "Provisioning", "Profiles"),
 					Path.Combine (appDataLocal, "maui", "iOS", "Provisioning", "Profiles")
 				};
 			}


### PR DESCRIPTION
Dev17 still generates provisioning information in the legacy Xamarin paths, so we need a way for this code to consider both new and legacy paths. This fixes an issue where Dev17 fails to build with newer iOS SDK versions that relies only on new MAUI paths. The reason of the failure is because Dev17 uses legacy paths and the iOS SDK looks in new paths.

Fixes P0 bug #2505126